### PR TITLE
Adding functionality to arm/disarm annex

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -209,7 +209,7 @@ class Client {
 
         return new Promise(function(resolve, reject) {
 
-            if (command != 'Disarm' && command != 'Total' && command != 'Partial') {
+            if (command != 'Disarm' && command != 'Total' && command != 'Partial' && command != 'ArmAnnex' && command != 'DisarmAnnex') {
                 reject(new SectorAlarmError('ERR_INVALID_COMMAND','Invalid command sent to act on site. Should be Disarm, Total or Partial'));
             }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -26,6 +26,12 @@ class Parser {
                 partialArmingAvailable: function (input) {
                     return input.Panel.PartialAvalible;
                 },
+                annexAvailable: function (input) {
+                    return input.Panel.AnnexAvalible;
+                },
+                annexStatus: function (input) {
+                    return input.Panel.StatusAnnex;
+                },
                 user: function(input){
                     return input.user;
                 }
@@ -55,6 +61,10 @@ class Parser {
                     action: function(input) {
                         if (input.EventType == 'partialarmed')
                             return 'partialArmed';
+                        else if (input.EventType == 'armedannex')
+                            return 'armedAnnex'
+                        else if (input.EventType == 'disarmedAnnex')
+                            return 'disarmedAnnex'
                         else
                             return input.EventType;
                     },
@@ -92,7 +102,7 @@ class Parser {
                 armedStatus: function(input) {
                     if (input.panelData.ArmedStatus == 'partialarmed')
                         return 'partialArmed';
-                    else
+                    else 
                         return input.panelData.ArmedStatus;
                 }
             });

--- a/lib/site.js
+++ b/lib/site.js
@@ -71,9 +71,22 @@ module.exports = class Site {
 
     }
 
+    annexArm(code) {
+        return Promise.resolve()
+            .then(() => client.act(this._siteId, this._sessionCookie, code, 'ArmAnnex'))
+            .then(json => parser.transformActionToOutput(json));
+
+    }
+
     disarm(code) {
         return Promise.resolve()
             .then(() => client.act(this._siteId, this._sessionCookie, code, 'Disarm'))
+            .then(json => parser.transformActionToOutput(json));
+    }
+
+    annexDisarm(code) {
+        return Promise.resolve()
+            .then(() => client.act(this._siteId, this._sessionCookie, code, 'DisarmAnnex'))
             .then(json => parser.transformActionToOutput(json));
     }
 };

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -143,7 +143,23 @@ describe('parser.js', function() {
                     .then(output => {
                         expect(output[0].action).to.be.equal('partialArmed');
                     });
-        });    
+        });  
+
+        it('a history input annex armed status, is transformed to camelCase', function() {
+
+            var input = JSON.stringify({
+                "LogDetails":[{
+                    "Time": '2017-06-18T16:17:00',
+                    "EventType": "armedannex",
+                    "User": "a person"
+                }]
+            });
+
+            return parser.transformHistoryToOutput(input)
+                    .then(output => {
+                        expect(output[0].action).to.be.equal('armedAnnex');
+                    });
+        });   
         
         it('a history inputs user is Kod, translate to Code', function() {
 

--- a/test/site-test.js
+++ b/test/site-test.js
@@ -62,6 +62,7 @@ describe('site.js', function() {
             statusParserStub.restore();
         });
 
+
         it('calls status and history on client, and transformStatusToOutput on parser', function() {
             return site.status()
                 .then(history => {
@@ -214,6 +215,72 @@ describe('site.js', function() {
 
         it('calling partialArm, calls act on client and transformActionToOutput on parser', function () {
             return site.partialArm('fake')
+                .then(response => {
+                    sinon.assert.calledOnce(actStub);
+                    sinon.assert.calledOnce(parserStub);
+                });
+        });
+    });
+
+    describe('#annexArm', function () {
+        var actStub, parserStub, site;
+        
+        beforeEach(function() {
+            actStub = sinon.stub(client, 'act');
+            parserStub = sinon.stub(parser, 'transformActionToOutput');
+            actStub.resolves({ "response": "aresponse"});
+            parserStub.resolves({ "output": "output"});
+            site = new Site('email', 'password', 'siteId');
+            site._sessionCookie = 'sessionCookie';
+        });
+
+        afterEach(function() {
+            actStub.restore();
+            parserStub.restore();
+        });
+
+        it('calls act on client, with correct parameters', function() {
+            return site.annexArm('code')
+                .then(response => {
+                    sinon.assert.calledWith(actStub, 'siteId', 'sessionCookie', 'code', 'ArmAnnex');
+                });
+        });
+
+        it('calling arm annex, calls act on client and transformActionToOutput on parser', function () {
+            return site.annexArm('fake')
+                .then(response => {
+                    sinon.assert.calledOnce(actStub);
+                    sinon.assert.calledOnce(parserStub);
+                });
+        });
+    });
+
+    describe('#annexDisarm', function () {
+        var actStub, parserStub, site;
+        
+        beforeEach(function() {
+            actStub = sinon.stub(client, 'act');
+            parserStub = sinon.stub(parser, 'transformActionToOutput');
+            actStub.resolves({ "response": "aresponse"});
+            parserStub.resolves({ "output": "output"});
+            site = new Site('email', 'password', 'siteId');
+            site._sessionCookie = 'sessionCookie';
+        });
+
+        afterEach(function() {
+            actStub.restore();
+            parserStub.restore();
+        });
+
+        it('calls act on client, with correct parameters', function() {
+            return site.annexDisarm('code')
+                .then(response => {
+                    sinon.assert.calledWith(actStub, 'siteId', 'sessionCookie', 'code', 'DisarmAnnex');
+                });
+        });
+
+        it('calling disarm annex, calls act on client and transformActionToOutput on parser', function () {
+            return site.annexDisarm('fake')
                 .then(response => {
                     sinon.assert.calledOnce(actStub);
                     sinon.assert.calledOnce(parserStub);


### PR DESCRIPTION
Utilizing Sectoralarm API fuction to arm and disarm annex buildings, such as garage or outhouses. site.js now also returns annex events from _history()_ and annex status from _status()_. Trying to be true to the format and had the parser do camel case for events/status. 

Added some very basic unit testing of new features. Could possibly improve somewhat. 